### PR TITLE
Fix: Reset combine node toggle tracking on split

### DIFF
--- a/macros/DWS_Core.js
+++ b/macros/DWS_Core.js
@@ -523,7 +523,7 @@ function init() {
             }
 
             // DEFAULT NODE 1 ON FOR TWO WAY TRIGGERS
-            DWS_COMBINE_NODE1 == 'on';
+            DWS_COMBINE_NODE1 = 'on';
           }          
           break;
 
@@ -1412,6 +1412,10 @@ function createPanels(panelState)
   switch(panelState)
   {
     case 'Split':
+      // RESET COMBINE NODE TOGGLE TRACKING
+      DWS_COMBINE_NODE1 = 'off';
+      DWS_COMBINE_NODE2 = 'off';
+      
       // PERFORM NWAY CHECK TO DETERMINE ROOM CONTROLS PANEL
       if (DWS.NWAY == 'Three Way')
       {


### PR DESCRIPTION
## Description
Fixes a bug in 3-way divisible rooms where the system would "remember" previous room selections even after the rooms were split. 

Previously, if a user combined **Node 1**, split the rooms back to normal, and then tried to combine only **Node 2**, the system would mistakenly combine *all three rooms* together. This was happening because the old selection for Node 1 was never cleared in the background. This PR ensures that all room selections are fully reset to 'off' during a "Split" operation.

**Fixes #2 **

## Changes Made
- Fixed assignment typo for `DWS_COMBINE_NODE1` (`==` changed to `=`).
- Added state reset logic for `DWS_COMBINE_NODE1` and `DWS_COMBINE_NODE2` trackers to `'off'` inside `createPanels()` when the state is set to `Split`.

## How to Test

**Scenario 1: Independent Node Toggling**
1. Select Node 1 and combine it with the Primary Node.
2. Split the rooms.
3. Toggle Node 2 to combine with the Primary Node.
4. Verify that *only* Node 2 combines and Node 1 properly remains split.

**Scenario 2: State Reset Validation (Alert Message)**
1. Combine Node 1 (or both Node 1 and Node 2).
2. Split the rooms.
3. Attempt to click "Combine Rooms" again *without* toggling any nodes first.
4. Verify that the "Selection Required" alert appears with the text "Please select one or more Workspace(s)." (This confirms that the previous node selections were successfully cleared during the split).