### PR TITLE
Fix: Prevent split nodes from tracking Core state in partial combinations

### DIFF
--- a/macros/DWS_Core.js
+++ b/macros/DWS_Core.js
@@ -201,41 +201,13 @@ function init() {
   //  EVENT LISTENER FOR STANDBY STATES  //
   //=====================================//
   xapi.Status.Standby.State.on(state => {
-    if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1' || DWS_CUR_STATE == 'Combined Node2')
-    {
-      if (state == 'Halfwake')
-      {
-        // ACTIVATE REMOTE SLEEPMODE
-        if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-          sendMessage(DWS.NODE1_HOST, "Halfwake");
-        }
-        if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-        {
-          sendMessage(DWS.NODE2_HOST, "Halfwake");
-        }
-      }
-      else if (state == 'EnteringStandby' || state == 'Standby')
-      {
-        // ACTIVATE REMOTE SLEEPMODE
-        if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-          sendMessage(DWS.NODE1_HOST, "Standby");
-        }
-        if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-        {
-          sendMessage(DWS.NODE2_HOST, "Standby");
-        }
-      }
-      else if (state == 'Off')
-      {
-        // ACTIVATE REMOTE SLEEPMODE
-        if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-          sendMessage(DWS.NODE1_HOST, "Awake");
-        }
-        if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-        {
-          sendMessage(DWS.NODE2_HOST, "Awake");
-        }
-      }
+    let message = '';
+    if (state == 'Halfwake') message = "Halfwake";
+    else if (state == 'EnteringStandby' || state == 'Standby') message = "Standby";
+    else if (state == 'Off') message = "Awake";
+
+    if (message) {
+      sendToCombinedNodes(message);
     }
   })
 
@@ -243,16 +215,7 @@ function init() {
   //  EVENT LISTENER FOR VOLUME MATCHING  //
   //======================================//
   xapi.Status.Audio.Volume.on(volume => {
-    if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1' || DWS_CUR_STATE == 'Combined Node2')
-    {
-      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-        sendMessage(DWS.NODE1_HOST,"Volume:"+volume);
-      }
-      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-        {
-          sendMessage(DWS.NODE2_HOST,"Volume:"+volume);
-        }
-    }
+    sendToCombinedNodes("Volume:"+volume);
   })
 
   //=======================================//
@@ -359,13 +322,7 @@ function init() {
       xapi.Command.Cameras.PresenterTrack.Set({ Mode: 'Persistent' });
 
       // ACTIVATE REMOTE SPEAKERTRACK
-      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-        sendMessage(DWS.NODE1_HOST, "EnableST");
-      }
-      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-      {
-        sendMessage(DWS.NODE2_HOST, "EnableST");
-      }
+      sendToCombinedNodes("EnableST");
     }
     else if (event.PanelId == 'dws_automation_enabled')
     {
@@ -388,13 +345,7 @@ function init() {
       xapi.Command.Cameras.SpeakerTrack.Deactivate();
 
       // DEACTIVE REMOTE SPEAKERTRACK
-      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-        sendMessage(DWS.NODE1_HOST, "DisableST");
-      }
-      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-      {
-        sendMessage(DWS.NODE2_HOST, "DisableST");
-      }
+      sendToCombinedNodes("DisableST");
     }
     else if (event.PanelId == 'dws_fixed_sxs')
     {
@@ -424,13 +375,7 @@ function init() {
       xapi.Command.Cameras.SpeakerTrack.Deactivate();
 
       // ACTIVATE REMOTE SPEAKERTRACK
-      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-        sendMessage(DWS.NODE1_HOST, "DisableST");
-      }
-      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-      {
-        sendMessage(DWS.NODE2_HOST, "DisableST");
-      }
+      sendToCombinedNodes("DisableST");
     }
     else if (event.PanelId == 'dws_fixed_randp')
     {
@@ -465,13 +410,7 @@ function init() {
           xapi.Command.Cameras.SpeakerTrack.Deactivate();
 
           // DISABLE REMOTE SPEAKERTRACK
-          if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
-            sendMessage(DWS.NODE1_HOST, "DisableST");
-          }
-          if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
-          {
-            sendMessage(DWS.NODE2_HOST, "DisableST");
-          }
+          sendToCombinedNodes("DisableST");
         }
         else
         {
@@ -2636,6 +2575,15 @@ async function startAZM() {
   startAZMZoneListener();
   startCallListener();
   await AZM.Command.Zone.Monitor.Stop();
+}
+
+function sendToCombinedNodes(message) {
+  if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+    sendMessage(DWS.NODE1_HOST, message);
+  }
+  if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2')) {
+    sendMessage(DWS.NODE2_HOST, message);
+  }
 }
 
 // START THE MACRO

--- a/macros/DWS_Core.js
+++ b/macros/DWS_Core.js
@@ -206,7 +206,9 @@ function init() {
       if (state == 'Halfwake')
       {
         // ACTIVATE REMOTE SLEEPMODE
-        sendMessage(DWS.NODE1_HOST, "Halfwake");
+        if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+          sendMessage(DWS.NODE1_HOST, "Halfwake");
+        }
         if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
         {
           sendMessage(DWS.NODE2_HOST, "Halfwake");
@@ -215,7 +217,9 @@ function init() {
       else if (state == 'EnteringStandby' || state == 'Standby')
       {
         // ACTIVATE REMOTE SLEEPMODE
-        sendMessage(DWS.NODE1_HOST, "Standby");
+        if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+          sendMessage(DWS.NODE1_HOST, "Standby");
+        }
         if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
         {
           sendMessage(DWS.NODE2_HOST, "Standby");
@@ -224,7 +228,9 @@ function init() {
       else if (state == 'Off')
       {
         // ACTIVATE REMOTE SLEEPMODE
-        sendMessage(DWS.NODE1_HOST, "Awake");
+        if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+          sendMessage(DWS.NODE1_HOST, "Awake");
+        }
         if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
         {
           sendMessage(DWS.NODE2_HOST, "Awake");
@@ -239,7 +245,9 @@ function init() {
   xapi.Status.Audio.Volume.on(volume => {
     if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1' || DWS_CUR_STATE == 'Combined Node2')
     {
-      sendMessage(DWS.NODE1_HOST,"Volume:"+volume);
+      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+        sendMessage(DWS.NODE1_HOST,"Volume:"+volume);
+      }
       if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
         {
           sendMessage(DWS.NODE2_HOST,"Volume:"+volume);
@@ -351,8 +359,10 @@ function init() {
       xapi.Command.Cameras.PresenterTrack.Set({ Mode: 'Persistent' });
 
       // ACTIVATE REMOTE SPEAKERTRACK
-      sendMessage(DWS.NODE1_HOST, "EnableST");
-      if (DWS.NWAY == 'Three Way')
+      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+        sendMessage(DWS.NODE1_HOST, "EnableST");
+      }
+      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
       {
         sendMessage(DWS.NODE2_HOST, "EnableST");
       }
@@ -378,8 +388,10 @@ function init() {
       xapi.Command.Cameras.SpeakerTrack.Deactivate();
 
       // DEACTIVE REMOTE SPEAKERTRACK
-      sendMessage(DWS.NODE1_HOST, "DisableST");
-      if (DWS.NWAY == 'Three Way')
+      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+        sendMessage(DWS.NODE1_HOST, "DisableST");
+      }
+      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
       {
         sendMessage(DWS.NODE2_HOST, "DisableST");
       }
@@ -412,8 +424,10 @@ function init() {
       xapi.Command.Cameras.SpeakerTrack.Deactivate();
 
       // ACTIVATE REMOTE SPEAKERTRACK
-      sendMessage(DWS.NODE1_HOST, "DisableST");
-      if (DWS.NWAY == 'Three Way')
+      if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+        sendMessage(DWS.NODE1_HOST, "DisableST");
+      }
+      if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
       {
         sendMessage(DWS.NODE2_HOST, "DisableST");
       }
@@ -451,8 +465,10 @@ function init() {
           xapi.Command.Cameras.SpeakerTrack.Deactivate();
 
           // DISABLE REMOTE SPEAKERTRACK
-          sendMessage(DWS.NODE1_HOST, "DisableST");
-          if (DWS.NWAY == 'Three Way')
+          if (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node1') {
+            sendMessage(DWS.NODE1_HOST, "DisableST");
+          }
+          if (DWS.NWAY == 'Three Way' && (DWS_CUR_STATE == 'Combined All' || DWS_CUR_STATE == 'Combined Node2'))
           {
             sendMessage(DWS.NODE2_HOST, "DisableST");
           }


### PR DESCRIPTION
### **Summary:**
This PR fixes a bug where independent nodes were incorrectly receiving and mirroring state changes from the Core when the room was only partially combined. 

### **Context & Fix:**
Previously, the `DWS_Core.js` macro sent `Volume`, `Standby`, and Camera `SpeakerTrack` commands to other nodes whenever *any* combined state was active. This meant interacting with the Core would inadvertently disrupt a split node by forcing it to change its state.
To fix this and DRY up the code, this PR introduces a `sendToCombinedNodes(message)` helper function. The `xapi` listeners for Volume and Standby, as well as the Camera UI control handlers, have been refactored to use this helper. The helper strictly checks `DWS_CUR_STATE` to guarantee that messages are exclusively routed to nodes that are actively combined with the Core.

### **Related Issue:**
*Closes #10*

### **Testing Performed:**
- Verified JavaScript syntax compilation for `DWS_Core.js`.
- Logically verified that `sendToCombinedNodes` prevents execution when the system is in a `Split` state or when targeting an uncombined node.