### PR TITLE
fix: enhance AZM startup logic

### DIFF
--- a/macros/DWS_Core.js
+++ b/macros/DWS_Core.js
@@ -695,7 +695,8 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
         xapi.Status.Audio.Volume.get()
         .then(volume => {
           sendMessage(DWS.NODE1_HOST,"Volume:"+volume);
-          sendMessage(DWS.NODE2_HOST,"Volume:"+volume);
+          // Wait 250ms securely before sending Node 2 to avoid exhausting the HttpClient connections
+          setTimeout(() => sendMessage(DWS.NODE2_HOST,"Volume:"+volume), 250);
         })
 
         // UPDATE VLANS FOR ACCESSORIES

--- a/macros/DWS_Core.js
+++ b/macros/DWS_Core.js
@@ -49,6 +49,9 @@ let DWS_TEMP_NAVS = [];
 let DWS_NODE2_MICS = 0;
 let DWS_HOLD_TIME;
 let DWS_LAST_CAMERA;
+let DWS_AZM_STARTUP_TIMER;
+let DWS_AZM_MIC_CHECK_INTERVAL;
+let DWS_MIGRATION_DEVICE_LISTENER;
 let DWS_DUCK_STATE = 'Unducked';
 let SWITCH_MODEL;
 let SWITCH_SERIAL;
@@ -58,7 +61,7 @@ let DWS_NODE1_MICS = DWS.NODE1_MICS.length;
 
 if (DWS.NWAY == 'Three Way')
 {
-  let DWS_NODE2_MICS = DWS.NODE2_MICS.length;
+  DWS_NODE2_MICS = DWS.NODE2_MICS.length;
 }
 
 let DWS_NODE1_NAVS = 1;
@@ -706,7 +709,7 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
         setPrimaryState('Combined All');
 
         // INITIALIZE AZM WITH A 165 DELAY
-        setTimeout(() => {startAZM()}, 165000);
+        DWS_AZM_STARTUP_TIMER = setTimeout(() => {initiateAZMStartup(DWS_NODE1_MICS + DWS_NODE2_MICS)}, 165000);
 
         if (DWS.COMBINED_BANNER)
         {
@@ -734,7 +737,7 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
         setPrimaryState('Combined Node1');
 
         // INITIALIZE AZM WITH A 165 DELAY
-        setTimeout(() => {startAZM()}, 165000);
+        DWS_AZM_STARTUP_TIMER = setTimeout(() => {initiateAZMStartup(DWS_NODE1_MICS)}, 165000);
 
         if (DWS.COMBINED_BANNER)
         {
@@ -762,7 +765,7 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
         setPrimaryState('Combined Node2');
 
         // INITIALIZE AZM WITH A 165 DELAY
-        setTimeout(() => {startAZM()}, 165000);
+        DWS_AZM_STARTUP_TIMER = setTimeout(() => {initiateAZMStartup(DWS_NODE2_MICS)}, 165000);
 
         if (DWS.COMBINED_BANNER)
         {
@@ -791,7 +794,7 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
       setPrimaryState('Combined Node1');
 
       // INITIALIZE AZM WITH A 165 DELAY
-      setTimeout(() => {startAZM()}, 165000);
+      DWS_AZM_STARTUP_TIMER = setTimeout(() => {initiateAZMStartup(DWS_NODE1_MICS)}, 165000);
 
       if (DWS.COMBINED_BANNER)
       {
@@ -816,7 +819,7 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
     let FOUND_MICS = 0;
 
     // MONITOR FOR MIGRATED DEVICES AND CONFIGURE ACCORDING TO USER SETTINGS
-    const REG_DEVICES = xapi.Status.Peripherals.ConnectedDevice
+    DWS_MIGRATION_DEVICE_LISTENER = xapi.Status.Peripherals.ConnectedDevice
     .on(device => {
       if (device.Status === 'Connected') 
       {
@@ -878,7 +881,12 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
             DWS_TIMER = 170000;
 
             // STOP LISTENING FOR DEVICE REGISTRATION EVENTS
-            setTimeout(() => {REG_DEVICES()}, 5000);
+            setTimeout(() => {
+              if (DWS_MIGRATION_DEVICE_LISTENER) {
+                DWS_MIGRATION_DEVICE_LISTENER();
+                DWS_MIGRATION_DEVICE_LISTENER = null;
+              }
+            }, 5000);
           }
         }           
         else if (DWS_CUR_STATE == 'Combined Node1')
@@ -891,7 +899,12 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
             DWS_TIMER = 170000;
 
             // STOP LISTENING FOR DEVICE REGISTRATION EVENTS
-            setTimeout(() => {REG_DEVICES()}, 5000);
+            setTimeout(() => {
+              if (DWS_MIGRATION_DEVICE_LISTENER) {
+                DWS_MIGRATION_DEVICE_LISTENER();
+                DWS_MIGRATION_DEVICE_LISTENER = null;
+              }
+            }, 5000);
           }
         } 
         else if (DWS_CUR_STATE == 'Combined Node2')
@@ -904,7 +917,12 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
             DWS_TIMER = 170000;
 
             // STOP LISTENING FOR DEVICE REGISTRATION EVENTS
-            setTimeout(() => {REG_DEVICES()}, 5000);
+            setTimeout(() => {
+              if (DWS_MIGRATION_DEVICE_LISTENER) {
+                DWS_MIGRATION_DEVICE_LISTENER();
+                DWS_MIGRATION_DEVICE_LISTENER = null;
+              }
+            }, 5000);
           }
         }        
       }      
@@ -943,6 +961,18 @@ xapi.Event.UserInterface.Message.Prompt.Response.on(value => {
 
     // UPDATE SAVED STATE IN CASE OF MACRO RESET / REBOOT
     setPrimaryState("Split");  
+
+    // CANCEL ANY PENDING AZM STARTUP TIMERS AND LISTENERS FROM A COMBINE EVENT 
+    clearTimeout(DWS_AZM_STARTUP_TIMER); 
+    clearInterval(DWS_AZM_MIC_CHECK_INTERVAL); 
+    if (DWS_MIGRATION_DEVICE_LISTENER) { 
+      DWS_MIGRATION_DEVICE_LISTENER(); 
+      DWS_MIGRATION_DEVICE_LISTENER = null; 
+    }   
+    
+    // WIPE TEMPORARY ARRAYS TO ENSURE FRESH STATE ON NEXT COMBINE 
+    DWS_TEMP_MICS = []; 
+    DWS_TEMP_NAVS = [];
 
     // CONFIGURE DELAY FOR AUDIO OUTPUTS
     setPrimaryDelay(0);
@@ -1920,23 +1950,31 @@ function pairSecondaryNav(panelId, location, mode)
 //===========================//
 //  AZM SUPPORTED FUNCTIONS  //
 //===========================//
-function buildAZMProfile(state) 
+function buildAZMProfile(state, availableMics) 
 {
   let PRIMARY_ZONE = [];
   let NODE1_ZONE = [];
   let NODE2_ZONE = [];
 
   DWS.PRIMARY_MICS.forEach(element => { 
-    PRIMARY_ZONE.push({Serial: element, SubId: [1]})
+    if (!availableMics || availableMics.includes(element)) {
+      PRIMARY_ZONE.push({Serial: element, SubId: [1]})
+    }
   });
 
   DWS.NODE1_MICS.forEach(element => { 
-    NODE1_ZONE.push({Serial: element, SubId: [1]})
+    if (!availableMics || availableMics.includes(element)) {
+      NODE1_ZONE.push({Serial: element, SubId: [1]})
+    }
   });
 
-  DWS.NODE2_MICS.forEach(element => { 
-    NODE2_ZONE.push({Serial: element, SubId: [1]})
-  });
+  if (DWS.NODE2_MICS) {
+    DWS.NODE2_MICS.forEach(element => { 
+      if (!availableMics || availableMics.includes(element)) {
+        NODE2_ZONE.push({Serial: element, SubId: [1]})
+      }
+    });
+  }
 
   let PRESENTER_ZONE = [];
 
@@ -2010,61 +2048,37 @@ function buildAZMProfile(state)
         },
         VoiceActivityDetection: 'On' 
       },
-      Zones: [
-        {
-          Label: 'PRIMARY ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_PRI,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',
-            Connectors: [...PRIMARY_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 1,
-              Layout: 'Equal'
-            }
-          }
-        },
-        {
-          Label: 'NODE 1 ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_NODE1,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',                   
-            Connectors: [ ...NODE1_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 2,
-              Layout: 'Equal'
-            }
-          }
-        },
-        {
-          Label: 'NODE 2 ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_NODE2,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',                   
-            Connectors: [ ...NODE2_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 3,
-              Layout: 'Equal'
-            }
-          }
-        },
-        ...PRESENTER_ZONE
-      ]
+      Zones: []
     }
+
+    if (PRIMARY_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'PRIMARY ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_PRI, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...PRIMARY_ZONE] },
+        Assets: { Camera: { InputConnector: 1, Layout: 'Equal' } }
+      });
+    }
+
+    if (NODE1_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'NODE 1 ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_NODE1, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...NODE1_ZONE] },
+        Assets: { Camera: { InputConnector: 2, Layout: 'Equal' } }
+      });
+    }
+
+    if (NODE2_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'NODE 2 ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_NODE2, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...NODE2_ZONE] },
+        Assets: { Camera: { InputConnector: 3, Layout: 'Equal' } }
+      });
+    }
+
+    DWS_AZM_PROFILE.Zones.push(...PRESENTER_ZONE);
   }
   else if (state == 'Combined Node1')
   {
@@ -2080,44 +2094,28 @@ function buildAZMProfile(state)
         },
         VoiceActivityDetection: 'On' 
       },
-      Zones: [
-        {
-          Label: 'PRIMARY ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_PRI,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',
-            Connectors: [...PRIMARY_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 1,
-              Layout: 'Equal'
-            }
-          }
-        },
-        {
-          Label: 'NODE 1 ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_NODE1,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',                   
-            Connectors: [ ...NODE1_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 2,
-              Layout: 'Equal'
-            }
-          }
-        },
-        ...PRESENTER_ZONE
-      ]
+      Zones: []
     }
+
+    if (PRIMARY_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'PRIMARY ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_PRI, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...PRIMARY_ZONE] },
+        Assets: { Camera: { InputConnector: 1, Layout: 'Equal' } }
+      });
+    }
+
+    if (NODE1_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'NODE 1 ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_NODE1, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...NODE1_ZONE] },
+        Assets: { Camera: { InputConnector: 2, Layout: 'Equal' } }
+      });
+    }
+
+    DWS_AZM_PROFILE.Zones.push(...PRESENTER_ZONE);
   }
   else if (state == 'Combined Node2')
   {
@@ -2133,44 +2131,28 @@ function buildAZMProfile(state)
         },
         VoiceActivityDetection: 'On' 
       },
-      Zones: [
-        {
-          Label: 'PRIMARY ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_PRI,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',
-            Connectors: [...PRIMARY_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 1,
-              Layout: 'Equal'
-            }
-          }
-        },
-        {
-          Label: 'NODE 2 ROOM',
-          Independent_Threshold: {
-            High: DWS.MICS_HIGH_NODE2,                           
-            Low: 20                              
-          },
-          MicrophoneAssignment: {
-            Type: 'Ethernet',                   
-            Connectors: [ ...NODE2_ZONE]
-          },
-          Assets: {                             
-            Camera: {
-              InputConnector: 3,
-              Layout: 'Equal'
-            }
-          }
-        },
-        ...PRESENTER_ZONE
-      ]
+      Zones: []
     }
+
+    if (PRIMARY_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'PRIMARY ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_PRI, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...PRIMARY_ZONE] },
+        Assets: { Camera: { InputConnector: 1, Layout: 'Equal' } }
+      });
+    }
+
+    if (NODE2_ZONE.length > 0) {
+      DWS_AZM_PROFILE.Zones.push({
+        Label: 'NODE 2 ROOM',
+        Independent_Threshold: { High: DWS.MICS_HIGH_NODE2, Low: 20 },
+        MicrophoneAssignment: { Type: 'Ethernet', Connectors: [...NODE2_ZONE] },
+        Assets: { Camera: { InputConnector: 3, Layout: 'Equal' } }
+      });
+    }
+
+    DWS_AZM_PROFILE.Zones.push(...PRESENTER_ZONE);
   }
   else
   {
@@ -2544,12 +2526,107 @@ async function handleCallStatus(event)
   })   
 }
 
+function countConnectedMigratingMics() {
+  if (DWS_CUR_STATE == 'Combined All') {
+    return DWS_TEMP_MICS.filter(serial => DWS.NODE1_MICS.includes(serial) || DWS.NODE2_MICS.includes(serial)).length;
+  } else if (DWS_CUR_STATE == 'Combined Node1') {
+    return DWS_TEMP_MICS.filter(serial => DWS.NODE1_MICS.includes(serial)).length;
+  } else if (DWS_CUR_STATE == 'Combined Node2') {
+    return DWS_TEMP_MICS.filter(serial => DWS.NODE2_MICS.includes(serial)).length;
+  }
+  return 0;
+}
+
+function logMissingMics() {
+  xapi.Status.Peripherals.ConnectedDevice.get()
+    .then(devices => {
+      let connectedSerials = devices.filter(d => d.Type === 'AudioMicrophone').map(d => d.SerialNumber);
+      let missing = [];
+      
+      if (DWS.PRIMARY_MICS) {
+        DWS.PRIMARY_MICS.forEach(mic => {
+          if (!connectedSerials.includes(mic)) missing.push(`[Primary Room: ${mic}]`);
+        });
+      }
+
+      if (DWS_CUR_STATE === 'Combined All' || DWS_CUR_STATE === 'Combined Node1') {
+        if (DWS.NODE1_MICS) {
+          DWS.NODE1_MICS.forEach(mic => {
+            if (!connectedSerials.includes(mic)) missing.push(`[Node 1 Room: ${mic}]`);
+          });
+        }
+      }
+
+      if (DWS_CUR_STATE === 'Combined All' || DWS_CUR_STATE === 'Combined Node2') {
+        if (DWS.NODE2_MICS) {
+          DWS.NODE2_MICS.forEach(mic => {
+            if (!connectedSerials.includes(mic)) missing.push(`[Node 2 Room: ${mic}]`);
+          });
+        }
+      }
+
+      if (missing.length > 0) {
+        console.log('Partial AZM: Missing mics: ' + missing.join(', '));
+      }
+    })
+    .catch(err => console.error("DWS: Failed to fetch connected mics for logging", err));
+}
+
+function initiateAZMStartup(expectedMigratingMics) {
+  if (countConnectedMigratingMics() >= expectedMigratingMics) {
+    if (DWS.DEBUG) console.debug("DWS: All expected mics found, starting AZM.");    
+    if (DWS_MIGRATION_DEVICE_LISTENER) {
+      DWS_MIGRATION_DEVICE_LISTENER();
+      DWS_MIGRATION_DEVICE_LISTENER = null;
+    }    
+    startAZM();
+  }
+  else {
+    if (DWS.DEBUG) console.warn("DWS: Microphones missing. Triggering 120s grace period listener.");
+    
+    const passiveListener = xapi.Status.Peripherals.ConnectedDevice.on(device => {
+      if (device.Status === 'Connected' && device.Type === 'AudioMicrophone') {
+        setTimeout(() => {
+          if (countConnectedMigratingMics() >= expectedMigratingMics) {
+            if (DWS.DEBUG) console.debug("DWS: Missing microphones joined during grace period. Starting full AZM.");
+            clearTimeout(DWS_AZM_MIC_CHECK_INTERVAL);
+            passiveListener();
+            if (DWS_MIGRATION_DEVICE_LISTENER) {
+              DWS_MIGRATION_DEVICE_LISTENER();
+              DWS_MIGRATION_DEVICE_LISTENER = null;
+            }
+            startAZM();
+          }
+        }, 100); // 100ms offset ensures the primary migration listener pushes to DWS_TEMP_MICS first
+      }
+    });
+
+    DWS_AZM_MIC_CHECK_INTERVAL = setTimeout(() => {
+      if (DWS.DEBUG) console.warn("DWS: AZM grace period expired. Starting partial AZM.");
+      logMissingMics();
+      passiveListener();
+      if (DWS_MIGRATION_DEVICE_LISTENER) {
+        DWS_MIGRATION_DEVICE_LISTENER();
+        DWS_MIGRATION_DEVICE_LISTENER = null;
+      }
+      startAZM();
+    }, 120000);
+  }
+}
+
 async function startAZM() {
-  let configurationProfile = buildAZMProfile(DWS_CUR_STATE);
-  await AZM.Command.Zone.Setup(configurationProfile);
-  startAZMZoneListener();
-  startCallListener();
-  await AZM.Command.Zone.Monitor.Stop();
+  try {
+    let devices = await xapi.Status.Peripherals.ConnectedDevice.get();
+    let connectedMics = devices.filter(d => d.Type === 'AudioMicrophone').map(d => d.SerialNumber);
+    
+    let configurationProfile = buildAZMProfile(DWS_CUR_STATE, connectedMics);
+    await AZM.Command.Zone.Setup(configurationProfile);
+    startAZMZoneListener();
+    startCallListener();
+    await AZM.Command.Zone.Monitor.Stop();
+  } catch (error) {
+    console.error("DWS: Failed to start AZM Zone monitoring", error);
+  }
 }
 
 function sendToCombinedNodes(message) {


### PR DESCRIPTION
## Reference
**Closes**: #13 

---

## Description
This PR resolves issue #13 by implementing a resilient, grace-period-based Acoustic Zone Monitoring (AZM) startup. It also includes two minor bug fixes: introducing staggered Node 2 volume updates to prevent socket pool exhaustion, and resolving a variable scope shadowing issue.

---

## Key Changes

### 1. Resilient AZM Startup & Mic Monitoring (Issue #13 Fix)
* **Grace Period Startup**: Implemented `initiateAZMStartup(...)` which waits up to 120s for migrating microphones. If microphones are missing after this duration, it logs the missing devices and loads an AZM zone profile with the connected mics.
* **Split Room Reset**: Properly clears all active AZM startup timers and purges temporary peripheral arrays upon split confirmation.
* **Profile Verification**: Updated `buildAZMProfile` to accept and verify connected device availability, mapping zones only if active microphones are present.

### 2. Minor Bug Fixes
* **Staggered Node 2 Volume Sync**: Staggered Node 2 volume updates by `250ms` using `setTimeout` to prevent concurrent `HttpClient` socket exhaustion during combines.
* **Variable Scope Correction**: Removed local `let` redeclaration on `DWS_NODE2_MICS` inside the three-way configuration block to ensure the outer scope variable updates correctly.

---

## Verification
Verify the AZM startup behavior by simulating the following room combine scenarios:

1. **Happy Path (All Mics Connected)**: Confirm combine triggers instant AZM startup.
   * *Expected log*: `DWS: All expected mics found, starting AZM.`
2. **Grace Path (Delayed Mic Join <120s)**: Disconnect a mic, combine rooms, then reconnect the mic within 120s.
   * *Expected log*: `DWS: Missing microphones joined during grace period. Starting full AZM.`
   * The 'InCall' buttons never break. Validate by making a call.
3. **Fallback Path (Mic permanently missing >120s)**: Disconnect a mic, combine rooms, and wait out the timer.
   * *Expected log*: `DWS: AZM grace period expired. Starting partial AZM.` followed by `Partial AZM: Missing mics: ...`
   *  The 'InCall' buttons never break. Validate by making a call.
4. **Split Cleanup**: Split the room during an active grace period.
   * *Result*: Pending timers are cancelled, device listener is unsubscribed, and temporary tracking arrays are reset to empty.